### PR TITLE
Implement Screenplay automation for user API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "validate-ia",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/src/abilities/CallAnApi.js
+++ b/src/abilities/CallAnApi.js
@@ -1,0 +1,29 @@
+export class CallAnApi {
+  constructor(baseURL) {
+    this.baseURL = baseURL.replace(/\/$/, "");
+  }
+
+  async get(path) {
+    return fetch(`${this.baseURL}${path}`);
+  }
+
+  async post(path, data) {
+    return fetch(`${this.baseURL}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  async put(path, data) {
+    return fetch(`${this.baseURL}${path}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  async delete(path) {
+    return fetch(`${this.baseURL}${path}`, { method: 'DELETE' });
+  }
+}

--- a/src/actor.js
+++ b/src/actor.js
@@ -1,0 +1,23 @@
+export class Actor {
+  constructor(name, abilities = {}) {
+    this.name = name;
+    this.abilities = abilities;
+  }
+
+  whoCan(abilityName, ability) {
+    this.abilities[abilityName] = ability;
+    return this;
+  }
+
+  abilityTo(abilityName) {
+    return this.abilities[abilityName];
+  }
+
+  async attemptsTo(...tasks) {
+    let result;
+    for (const task of tasks) {
+      result = await task.performAs(this);
+    }
+    return result;
+  }
+}

--- a/src/tasks/CreateUser.js
+++ b/src/tasks/CreateUser.js
@@ -1,0 +1,13 @@
+import { CallAnApi } from '../abilities/CallAnApi.js';
+
+export class CreateUser {
+  constructor(data) {
+    this.data = data;
+  }
+
+  async performAs(actor) {
+    const api = actor.abilityTo('CallAnApi');
+    const response = await api.post('/users', this.data);
+    return response.json();
+  }
+}

--- a/src/tasks/DeleteUser.js
+++ b/src/tasks/DeleteUser.js
@@ -1,0 +1,11 @@
+export class DeleteUser {
+  constructor(id) {
+    this.id = id;
+  }
+
+  async performAs(actor) {
+    const api = actor.abilityTo('CallAnApi');
+    const response = await api.delete(`/users/${this.id}`);
+    return response.json();
+  }
+}

--- a/src/tasks/GetAllUsers.js
+++ b/src/tasks/GetAllUsers.js
@@ -1,0 +1,7 @@
+export class GetAllUsers {
+  async performAs(actor) {
+    const api = actor.abilityTo('CallAnApi');
+    const response = await api.get('/users');
+    return response.json();
+  }
+}

--- a/src/tasks/GetUserById.js
+++ b/src/tasks/GetUserById.js
@@ -1,0 +1,11 @@
+export class GetUserById {
+  constructor(id) {
+    this.id = id;
+  }
+
+  async performAs(actor) {
+    const api = actor.abilityTo('CallAnApi');
+    const response = await api.get(`/users/${this.id}`);
+    return response.json();
+  }
+}

--- a/src/tasks/UpdateUser.js
+++ b/src/tasks/UpdateUser.js
@@ -1,0 +1,12 @@
+export class UpdateUser {
+  constructor(id, data) {
+    this.id = id;
+    this.data = data;
+  }
+
+  async performAs(actor) {
+    const api = actor.abilityTo('CallAnApi');
+    const response = await api.put(`/users/${this.id}`, this.data);
+    return response.json();
+  }
+}

--- a/tests/userRoutes.test.js
+++ b/tests/userRoutes.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { Actor } from '../src/actor.js';
+import { CallAnApi } from '../src/abilities/CallAnApi.js';
+import { CreateUser } from '../src/tasks/CreateUser.js';
+import { GetAllUsers } from '../src/tasks/GetAllUsers.js';
+import { GetUserById } from '../src/tasks/GetUserById.js';
+import { UpdateUser } from '../src/tasks/UpdateUser.js';
+import { DeleteUser } from '../src/tasks/DeleteUser.js';
+
+const baseURL = process.env.BASE_URL ?? 'http://localhost:3000';
+
+const actor = new Actor('API Tester').whoCan('CallAnApi', new CallAnApi(baseURL));
+
+test('user route automation using Screenplay pattern', async () => {
+  const newUser = { name: 'John Doe', email: 'john@example.com' };
+  const created = await actor.attemptsTo(new CreateUser(newUser));
+  assert.ok(created.id, 'User should have an id');
+
+  const users = await actor.attemptsTo(new GetAllUsers());
+  assert.ok(Array.isArray(users), 'Should return user array');
+
+  const fetched = await actor.attemptsTo(new GetUserById(created.id));
+  assert.equal(fetched.id, created.id);
+
+  const updated = await actor.attemptsTo(new UpdateUser(created.id, { name: 'John Updated' }));
+  assert.equal(updated.name, 'John Updated');
+
+  const deleted = await actor.attemptsTo(new DeleteUser(created.id));
+  assert.ok(deleted);
+});


### PR DESCRIPTION
## Summary
- use Node test runner and `fetch` to avoid external dependencies
- implement Actor and CallAnApi ability
- add Screenplay tasks for user CRUD routes
- create example test for the user routes

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a0828d4f8832388e9a149315b9a44